### PR TITLE
fix: avoid overlap in backward schedule

### DIFF
--- a/src/lib/usecases/scheduleBackward.ts
+++ b/src/lib/usecases/scheduleBackward.ts
@@ -11,6 +11,7 @@ export function scheduleBackward(
     const nodeMap = new Map(nodes.map(n => [n.id, { ...n }]));
     const succ = new Map<string, string[]>();
     const pred = new Map<string, string[]>();
+    const oneDayMs = 24 * 3600 * 1000;
 
     edges.forEach(e => {
         succ.set(e.source, [...(succ.get(e.source) ?? []), e.target]);
@@ -39,7 +40,8 @@ export function scheduleBackward(
             const d = new Date(sNode.start);
             minStartOfSucc = !minStartOfSucc || d < minStartOfSucc ? d : minStartOfSucc;
         }
-        const end = minStartOfSucc ?? terminalEnd;
+        const nextStart = minStartOfSucc ?? terminalEnd;
+        const end = new Date(nextStart.getTime() - oneDayMs);
         const start = new Date(end.getTime() - toWorkingMs(eff(node), settings));
         node.end = toISODate(end);
         node.start = toISODate(start);


### PR DESCRIPTION
## Summary
- prevent nodes from ending on the same day their successors start by subtracting one day

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68996f70c1e483248b9f6b87a7a057c6