### PR TITLE
feat: add AI-assisted task generation from context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "rete-render-utils": "^2.0.3",
     "rete-svelte-plugin": "^2.1.1",
     "sass": "^1.89.2",
-    "zod": "^4.0.16"
+    "zod": "^4.0.16",
+    "langchain": "^0.2.10",
+    "@langchain/openai": "^0.2.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",

--- a/src/lib/infrastructure/ai/taskGenerator.ts
+++ b/src/lib/infrastructure/ai/taskGenerator.ts
@@ -1,0 +1,45 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { StructuredOutputParser } from "langchain/output_parsers";
+import { z } from "zod";
+import type { NodeEntity } from "$lib/domain/entities";
+
+const schema = z.object({
+    tasks: z.array(
+        z.object({
+            name: z.string(),
+            effortHours: z.number().optional().default(8),
+        })
+    ),
+});
+
+const parser = StructuredOutputParser.fromZodSchema(schema);
+const formatInstructions = parser.getFormatInstructions();
+
+const model = new ChatOpenAI({ temperature: 0 });
+
+async function callChain(promptText: string, input: Record<string, string>): Promise<NodeEntity[]> {
+    const prompt = new PromptTemplate({
+        template: `${promptText}\n{format}`,
+        inputVariables: Object.keys(input),
+        partialVariables: { format: formatInstructions },
+    });
+    const chain = prompt.pipe(model).pipe(parser);
+    const result = await chain.invoke(input);
+    return result.tasks.map((t) => ({
+        id: "",
+        name: t.name,
+        effortHours: t.effortHours ?? 8,
+    }));
+}
+
+export async function decomposeTaskWithAI(task: string): Promise<NodeEntity[]> {
+    const text = "Break down the given task into smaller tasks. Return JSON.";
+    return callChain(text, { task });
+}
+
+export async function generateFinalDeliverableWithAI(goal: string): Promise<NodeEntity[]> {
+    const text = "Create a sequence of tasks leading to the final deliverable described. Return JSON.";
+    return callChain(text, { goal });
+}
+

--- a/src/lib/presentation/stores/i18n.ts
+++ b/src/lib/presentation/stores/i18n.ts
@@ -22,7 +22,9 @@ export const dictionary: Record<Locale, Record<string, string>> = {
     cancel: 'キャンセル',
     addNode: 'ノードを追加',
     deleteNode: 'ノードを削除',
-    deleteConnector: 'コネクタを削除'
+    deleteConnector: 'コネクタを削除',
+    decomposeTask: 'タスクを分解',
+    generateFinalTask: '最終成果物タスクを生成'
   },
   en: {
     align: 'Align',
@@ -42,7 +44,9 @@ export const dictionary: Record<Locale, Record<string, string>> = {
     cancel: 'Cancel',
     addNode: 'Add Node',
     deleteNode: 'Delete Node',
-    deleteConnector: 'Delete Connector'
+    deleteConnector: 'Delete Connector',
+    decomposeTask: 'Decompose Task',
+    generateFinalTask: 'Generate Final Task'
   }
 };
 


### PR DESCRIPTION
## Summary
- add translation strings for AI-driven task actions
- use LangChain to generate NodeEntity JSON for task decomposition and final tasks
- extend canvas and node context menus to call AI and merge generated nodes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689b0799df2c8324869c948a0e25b710