### PR TITLE
Log LLM request and response data

### DIFF
--- a/src/lib/infrastructure/ai/taskGenerator.ts
+++ b/src/lib/infrastructure/ai/taskGenerator.ts
@@ -54,11 +54,18 @@ async function callChain(
         partialVariables: { format: formatInstructions },
     });
 
-    const chain = prompt.pipe(model).pipe(parser);
-    const result = (await chain.invoke({
+    const formattedPrompt = await prompt.format({
         promptText,
         inputBlock,
-    })) as z.infer<typeof schema>;
+    });
+    console.log("[LLM REQUEST]", formattedPrompt);
+
+    const rawResponse = await model.invoke(formattedPrompt);
+    const responseText =
+        typeof rawResponse === "string" ? rawResponse : rawResponse.content;
+    console.log("[LLM RESPONSE]", responseText);
+
+    const result = (await parser.parse(responseText)) as z.infer<typeof schema>;
 
     return result.tasks.map((t: any) => ({
         id: "",


### PR DESCRIPTION
## Summary
- log formatted prompt before sending to the LLM
- log raw response after LLM invocation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: svelte-check found 1 error and 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b75a10c1c83248f7275b4bcb2db54