### PR TITLE
Add LLM chat panel with result acceptance

### DIFF
--- a/src/lib/infrastructure/ai/taskGenerator.ts
+++ b/src/lib/infrastructure/ai/taskGenerator.ts
@@ -75,18 +75,19 @@ async function callChain(
 }
 
 // タスク分解（日本語で返す）
-export async function decomposeTaskWithAI(task: string): Promise<NodeEntity[]> {
+export async function decomposeTaskWithAI(goal: string, task: string): Promise<NodeEntity[]> {
     const text =
-        "与えられたタスクをより小さなタスクへ分解してください。スキーマに厳密に従ったJSONのみを返してください。";
-    return callChain(text, { task });
+        "入力として goal（最終成果物の目的）と タスク（goal達成のためのタスクの一部）が与えられる。与えられたタスクは、goalに至る工程の中で特定の作業を示すものであり、そのタスクをさらに細かい作業単位に分解する。分解後のタスクは 1つにつき1つの作業内容 とし、複数の作業をまとめないこと。タスクは具体的かつ簡潔に記述し、分解したタスクだけでその元のタスクの内容が完全に実行できる状態にする。";
+    return callChain(text, { "goal": goal, "task": task });
 }
+
 
 // 最終成果物へ至るシーケンス生成（日本語で返す）
 export async function generateFinalDeliverableWithAI(
     goal: string
 ): Promise<NodeEntity[]> {
     const text =
-        "記述された最終成果物に到達するためのタスクのシーケンスを作成してください。スキーマに厳密に従ったJSONのみを返してください。";
+        "入力として与えられる goal を分析し、その最終成果物を実現するために最も適した エキスパート像（専門分野・役割） を具体的かつ明確に定義する。その定義したエキスパートとして、最終成果物に到達するためのタスクを順序立てて作成する。タスクは 1つにつき1つの作業内容 とし、複数の作業をまとめないこと。タスクは可能な限り具体的かつ簡潔に記述し、成果物までの全工程を漏れなくカバーする。";
     return callChain(text, { goal });
 }
 

--- a/src/lib/infrastructure/ai/taskGenerator.ts
+++ b/src/lib/infrastructure/ai/taskGenerator.ts
@@ -89,3 +89,10 @@ export async function generateFinalDeliverableWithAI(
         "記述された最終成果物に到達するためのタスクのシーケンスを作成してください。スキーマに厳密に従ったJSONのみを返してください。";
     return callChain(text, { goal });
 }
+
+// 任意のプロンプトからタスクを生成
+export async function generateTasksFromPrompt(
+    prompt: string,
+): Promise<NodeEntity[]> {
+    return callChain(prompt, {});
+}

--- a/src/lib/presentation/components/ChatPanel.svelte
+++ b/src/lib/presentation/components/ChatPanel.svelte
@@ -112,7 +112,7 @@
         border-left: 1px solid #ccc;
         display: flex;
         flex-direction: column;
-        height: 100%;
+        height: 90vh;
     }
     .messages {
         flex: 1;

--- a/src/lib/presentation/components/ChatPanel.svelte
+++ b/src/lib/presentation/components/ChatPanel.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+    import { generateTasksFromPrompt } from "$lib/infrastructure/ai/taskGenerator";
+    import { projectStore } from "$lib/presentation/stores/projectStore";
+    import { t } from "$lib/presentation/stores/i18n";
+    import { get } from "svelte/store";
+    import type { NodeEntity, EdgeEntity } from "$lib/domain/entities";
+
+    const INSERT_H_GAP = 240;
+
+    let prompt = $state("");
+    let lastPrompt = $state("");
+    let lastTasks = $state<NodeEntity[] | null>(null);
+    let loading = $state(false);
+    let tr = $state(get(t));
+
+    $effect(() => {
+        const un = t.subscribe((v) => (tr = v));
+        return () => un?.();
+    });
+
+    async function send() {
+        if (!prompt.trim() || loading) return;
+        lastPrompt = prompt;
+        prompt = "";
+        loading = true;
+        try {
+            lastTasks = await generateTasksFromPrompt(lastPrompt);
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function regenerate() {
+        if (!lastPrompt || loading) return;
+        loading = true;
+        try {
+            lastTasks = await generateTasksFromPrompt(lastPrompt);
+        } finally {
+            loading = false;
+        }
+    }
+
+    function accept() {
+        if (!lastTasks || lastTasks.length === 0) return;
+        projectStore.update((s) => {
+            const baseX = 0;
+            const baseY = 0;
+            const newNodes: NodeEntity[] = [];
+            const newEdges: EdgeEntity[] = [];
+            let prev: string | null = null;
+            lastTasks!.forEach((t, idx) => {
+                const id = `n${crypto.randomUUID().slice(0, 8)}`;
+                newNodes.push({
+                    id,
+                    name: t.name,
+                    effortHours: t.effortHours,
+                    position: { x: baseX + INSERT_H_GAP * idx, y: baseY },
+                });
+                if (prev)
+                    newEdges.push({
+                        id: `e${crypto.randomUUID().slice(0, 8)}`,
+                        source: prev,
+                        target: id,
+                    });
+                prev = id;
+            });
+            return {
+                ...s,
+                nodes: [...s.nodes, ...newNodes],
+                edges: [...s.edges, ...newEdges],
+            };
+        });
+        lastTasks = null;
+    }
+</script>
+
+<div class="chat-panel">
+    <div class="messages">
+        {#if lastTasks}
+            <div class="message">
+                <div class="prompt">{lastPrompt}</div>
+                <div class="tasks">
+                    <ul>
+                        {#each lastTasks as task}
+                            <li>{task.name} ({task.effortHours}h)</li>
+                        {/each}
+                    </ul>
+                </div>
+                <div class="actions">
+                    <button onclick={accept}>{tr.accept}</button>
+                    <button onclick={regenerate}>{tr.regenerate}</button>
+                </div>
+            </div>
+        {/if}
+    </div>
+    <div class="input-area">
+        <input
+            type="text"
+            bind:value={prompt}
+            placeholder={tr.promptPlaceholder}
+            onkeydown={(e: KeyboardEvent) => {
+                if (e.key === "Enter") send();
+            }}
+        />
+        <button onclick={send} disabled={loading}>{tr.sendPrompt}</button>
+    </div>
+</div>
+
+<style>
+    .chat-panel {
+        width: 300px;
+        border-left: 1px solid #ccc;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+    .messages {
+        flex: 1;
+        overflow: auto;
+        padding: 8px;
+    }
+    .input-area {
+        display: flex;
+        gap: 4px;
+        padding: 8px;
+    }
+    .actions {
+        margin-top: 8px;
+        display: flex;
+        gap: 4px;
+    }
+    .tasks ul {
+        padding-left: 16px;
+    }
+    .prompt {
+        font-weight: bold;
+        margin-bottom: 4px;
+    }
+</style>

--- a/src/lib/presentation/components/FlowCanvas.svelte
+++ b/src/lib/presentation/components/FlowCanvas.svelte
@@ -564,7 +564,7 @@
 <style>
     .canvas-root {
         width: 100%;
-        height: 100%;
+        height: 90%;
         position: relative;
     }
     .processing-overlay {

--- a/src/lib/presentation/components/FlowCanvas.svelte
+++ b/src/lib/presentation/components/FlowCanvas.svelte
@@ -453,12 +453,7 @@
 
 <svelte:window on:keydown={handleKeyDown} />
 
-<div
-    style:width="100vw"
-    style:height="100vh"
-    style:position="relative"
-    on:click={closeContextMenu}
->
+<div class="canvas-root" on:click={closeContextMenu}>
     <SvelteFlow
         {nodes}
         {edges}
@@ -505,6 +500,11 @@
 </div>
 
 <style>
+    .canvas-root {
+        width: 100%;
+        height: 100%;
+        position: relative;
+    }
     .processing-overlay {
         position: absolute;
         top: 0;

--- a/src/lib/presentation/stores/i18n.ts
+++ b/src/lib/presentation/stores/i18n.ts
@@ -26,7 +26,11 @@ export const dictionary: Record<Locale, Record<string, string>> = {
     deleteConnector: 'コネクタを削除',
     decomposeTask: 'タスクを分解',
     generateFinalTask: '最終成果物タスクを生成',
-    processing: '処理中...'
+    processing: '処理中...',
+    sendPrompt: '送信',
+    accept: '受け入れる',
+    regenerate: '再生成',
+    promptPlaceholder: 'プロンプトを入力...'
   },
   en: {
     align: 'Align',
@@ -50,7 +54,11 @@ export const dictionary: Record<Locale, Record<string, string>> = {
     deleteConnector: 'Delete Connector',
     decomposeTask: 'Decompose Task',
     generateFinalTask: 'Generate Final Task',
-    processing: 'Processing...'
+    processing: 'Processing...',
+    sendPrompt: 'Send',
+    accept: 'Accept',
+    regenerate: 'Regenerate',
+    promptPlaceholder: 'Enter prompt...'
   }
 };
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,23 @@
 <script lang="ts">
   import FlowCanvas from "$lib/presentation/components/FlowCanvas.svelte";
+  import ChatPanel from "$lib/presentation/components/ChatPanel.svelte";
 </script>
 
 <main class="container">
-  <FlowCanvas />
+  <div class="layout">
+    <div class="canvas-wrapper">
+      <FlowCanvas />
+    </div>
+    <ChatPanel />
+  </div>
 </main>
+
+<style>
+  .layout {
+    display: flex;
+    height: 100vh;
+  }
+  .canvas-wrapper {
+    flex: 1;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add side chat panel to send prompts to LLM and accept or regenerate generated tasks
- Extend i18n strings and AI infrastructure to support custom prompts
- Adjust page layout and canvas sizing to accommodate chat panel

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7c5127b08324a1fcf0add8d33b40