### PR TITLE
Localize AI task output by locale

### DIFF
--- a/src/lib/presentation/components/ChatPanel.svelte
+++ b/src/lib/presentation/components/ChatPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { generateTasksFromPrompt } from "$lib/infrastructure/ai/taskGenerator";
     import { projectStore } from "$lib/presentation/stores/projectStore";
-    import { t } from "$lib/presentation/stores/i18n";
+    import { t, locale, type Locale } from "$lib/presentation/stores/i18n";
     import { get } from "svelte/store";
     import type { NodeEntity, EdgeEntity } from "$lib/domain/entities";
 
@@ -12,9 +12,14 @@
     let lastTasks = $state<NodeEntity[] | null>(null);
     let loading = $state(false);
     let tr = $state(get(t));
+    let currentLocale = $state<Locale>(get(locale));
 
     $effect(() => {
         const un = t.subscribe((v) => (tr = v));
+        return () => un?.();
+    });
+    $effect(() => {
+        const un = locale.subscribe((v) => (currentLocale = v));
         return () => un?.();
     });
 
@@ -24,7 +29,7 @@
         prompt = "";
         loading = true;
         try {
-            lastTasks = await generateTasksFromPrompt(lastPrompt);
+            lastTasks = await generateTasksFromPrompt(lastPrompt, currentLocale);
         } finally {
             loading = false;
         }
@@ -34,7 +39,7 @@
         if (!lastPrompt || loading) return;
         loading = true;
         try {
-            lastTasks = await generateTasksFromPrompt(lastPrompt);
+            lastTasks = await generateTasksFromPrompt(lastPrompt, currentLocale);
         } finally {
             loading = false;
         }


### PR DESCRIPTION
## Summary
- ensure task generation prompts honor the selected UI language
- wire FlowCanvas and ChatPanel to forward the current locale to AI helpers
- centralize bilingual prompt templates for AI task generation

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_689bffecf0b08324b5afff618e929d11