### PR TITLE
feat: enhance UI with Tailwind patterns

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Tauri + SvelteKit + Typescript App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/lib/presentation/components/ChatPanel.svelte
+++ b/src/lib/presentation/components/ChatPanel.svelte
@@ -79,66 +79,49 @@
     }
 </script>
 
-<div class="chat-panel">
-    <div class="messages">
+<div class="flex h-full w-72 flex-col border-l border-gray-300 bg-white">
+    <div class="flex-1 space-y-4 overflow-auto p-4">
         {#if lastTasks}
-            <div class="message">
-                <div class="prompt">{lastPrompt}</div>
-                <div class="tasks">
-                    <ul>
-                        {#each lastTasks as task}
-                            <li>{task.name} ({task.effortHours}h)</li>
-                        {/each}
-                    </ul>
-                </div>
-                <div class="actions">
-                    <button onclick={accept}>{tr.accept}</button>
-                    <button onclick={regenerate}>{tr.regenerate}</button>
+            <div class="space-y-2">
+                <div class="font-semibold">{lastPrompt}</div>
+                <ul class="list-disc pl-5 text-sm">
+                    {#each lastTasks as task}
+                        <li>{task.name} ({task.effortHours}h)</li>
+                    {/each}
+                </ul>
+                <div class="flex gap-2 pt-2">
+                    <button
+                        class="rounded bg-blue-500 px-2 py-1 text-white hover:bg-blue-600"
+                        onclick={accept}
+                    >
+                        {tr.accept}
+                    </button>
+                    <button
+                        class="rounded bg-gray-200 px-2 py-1 hover:bg-gray-300"
+                        onclick={regenerate}
+                    >
+                        {tr.regenerate}
+                    </button>
                 </div>
             </div>
         {/if}
     </div>
-    <div class="input-area">
+    <div class="flex items-center gap-2 border-t border-gray-200 p-2">
         <input
             type="text"
+            class="flex-1 rounded border border-gray-300 px-2 py-1"
             bind:value={prompt}
             placeholder={tr.promptPlaceholder}
             onkeydown={(e: KeyboardEvent) => {
                 if (e.key === "Enter") send();
             }}
         />
-        <button onclick={send} disabled={loading}>{tr.sendPrompt}</button>
+        <button
+            class="rounded bg-green-500 px-3 py-1 text-white hover:bg-green-600 disabled:opacity-50"
+            onclick={send}
+            disabled={loading}
+        >
+            {tr.sendPrompt}
+        </button>
     </div>
 </div>
-
-<style>
-    .chat-panel {
-        width: 300px;
-        border-left: 1px solid #ccc;
-        display: flex;
-        flex-direction: column;
-        height: 90vh;
-    }
-    .messages {
-        flex: 1;
-        overflow: auto;
-        padding: 8px;
-    }
-    .input-area {
-        display: flex;
-        gap: 4px;
-        padding: 8px;
-    }
-    .actions {
-        margin-top: 8px;
-        display: flex;
-        gap: 4px;
-    }
-    .tasks ul {
-        padding-left: 16px;
-    }
-    .prompt {
-        font-weight: bold;
-        margin-bottom: 4px;
-    }
-</style>

--- a/src/lib/presentation/components/HeaderBar.svelte
+++ b/src/lib/presentation/components/HeaderBar.svelte
@@ -10,6 +10,9 @@
 
     const fs = new TauriFsAdapter();
 
+    const btnClass = "rounded bg-gray-200 px-2 py-1 hover:bg-gray-300";
+    const inputClass = "border rounded px-1";
+
     const fallback: ProjectSnapshot = {
         project: {
             name: "",
@@ -102,27 +105,29 @@
     }
 </script>
 
-<div class="flex gap-2 p-2 border-b">
-    <button onclick={runLayout}>{tr.align}</button>
-    <button onclick={runSchedule}>{tr.schedule}</button>
-    <button onclick={markCC}>{tr.criticalChain}</button>
-    <button onclick={onNew}>{tr.newProject}</button>
-    <button onclick={onSave}>{tr.save}</button>
-    <button onclick={onLoad}>{tr.load}</button>
+<div class="flex gap-2 border-b p-2">
+    <button class={btnClass} onclick={runLayout}>{tr.align}</button>
+    <button class={btnClass} onclick={runSchedule}>{tr.schedule}</button>
+    <button class={btnClass} onclick={markCC}>{tr.criticalChain}</button>
+    <button class={btnClass} onclick={onNew}>{tr.newProject}</button>
+    <button class={btnClass} onclick={onSave}>{tr.save}</button>
+    <button class={btnClass} onclick={onLoad}>{tr.load}</button>
 
     <div class="ml-auto flex items-center gap-2">
-        <label
+        <label class="flex items-center gap-1"
             >{tr.dueDate}
             <input
+                class={inputClass}
                 type="date"
                 value={snap?.project?.dueDate ?? ""}
                 onchange={(e: Event) =>
                     setDueDate((e.currentTarget as HTMLInputElement).value)}
             />
         </label>
-        <label
+        <label class="flex items-center gap-1"
             >{tr.projectBuffer}
             <input
+                class={inputClass}
                 type="number"
                 step="1"
                 min="0"
@@ -131,9 +136,10 @@
                     setPB((e.currentTarget as HTMLInputElement).value)}
             />
         </label>
-        <label
+        <label class="flex items-center gap-1"
             >{tr.use50}
             <input
+                class="h-4 w-4"
                 type="checkbox"
                 checked={!!snap?.project?.useFiftyPctEstimate}
                 onchange={(e: Event) =>
@@ -141,6 +147,7 @@
             />
         </label>
         <select
+            class={inputClass}
             bind:value={currentLocale}
             onchange={(e) =>
                 locale.set((e.currentTarget as HTMLSelectElement).value as Locale)}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script>
     import HeaderBar from "$lib/presentation/components/HeaderBar.svelte";
     import { SvelteFlowProvider } from "@xyflow/svelte";
+    import "../app.css";
 </script>
 
 <div class="h-screen w-screen flex flex-col">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,21 +3,11 @@
   import ChatPanel from "$lib/presentation/components/ChatPanel.svelte";
 </script>
 
-<main class="container">
-  <div class="layout">
-    <div class="canvas-wrapper">
+<main class="h-full">
+  <div class="flex h-full">
+    <div class="flex-1">
       <FlowCanvas />
     </div>
     <ChatPanel />
   </div>
 </main>
-
-<style>
-  .layout {
-    display: flex;
-    height: 100vh;
-  }
-  .canvas-wrapper {
-    flex: 1;
-  }
-</style>


### PR DESCRIPTION
## Summary
- load Tailwind CSS from CDN and include app styles
- restyle main page, chat panel, and header with Tailwind utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689c02db9db08324a8c2e22895ffef15