### PR TITLE
chore: log task generator interactions to file

### DIFF
--- a/src/lib/infrastructure/ai/taskGenerator.ts
+++ b/src/lib/infrastructure/ai/taskGenerator.ts
@@ -2,14 +2,46 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { StructuredOutputParser } from "@langchain/core/output_parsers";
 import { z } from "zod";
-import { appendFileSync } from "node:fs";
+import {
+    appendFileSync,
+    existsSync,
+    renameSync,
+    statSync,
+    unlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import type { NodeEntity } from "$lib/domain/entities";
 import type { Locale } from "$lib/presentation/stores/i18n";
 
 const LOG_FILE = join(process.cwd(), "task-generator.log");
+const MAX_LOG_SIZE = 1024 * 1024; // 1MB
+const MAX_LOG_GENERATIONS = 10;
+
+function rotateLogs() {
+    const oldest = `${LOG_FILE}.${MAX_LOG_GENERATIONS}`;
+    if (existsSync(oldest)) {
+        unlinkSync(oldest);
+    }
+    for (let i = MAX_LOG_GENERATIONS - 1; i >= 0; i--) {
+        const src = i === 0 ? LOG_FILE : `${LOG_FILE}.${i}`;
+        const dest = `${LOG_FILE}.${i + 1}`;
+        if (existsSync(src)) {
+            renameSync(src, dest);
+        }
+    }
+}
+
 function logToFile(message: string) {
-    appendFileSync(LOG_FILE, message + "\n");
+    try {
+        const size = existsSync(LOG_FILE) ? statSync(LOG_FILE).size : 0;
+        const newSize = size + Buffer.byteLength(message + "\n");
+        if (newSize > MAX_LOG_SIZE) {
+            rotateLogs();
+        }
+        appendFileSync(LOG_FILE, message + "\n");
+    } catch (error) {
+        console.error("logToFile error", error);
+    }
 }
 
 const schema = z.object({

--- a/src/lib/infrastructure/ai/taskGenerator.ts
+++ b/src/lib/infrastructure/ai/taskGenerator.ts
@@ -2,8 +2,15 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { StructuredOutputParser } from "@langchain/core/output_parsers";
 import { z } from "zod";
+import { appendFileSync } from "node:fs";
+import { join } from "node:path";
 import type { NodeEntity } from "$lib/domain/entities";
 import type { Locale } from "$lib/presentation/stores/i18n";
+
+const LOG_FILE = join(process.cwd(), "task-generator.log");
+function logToFile(message: string) {
+    appendFileSync(LOG_FILE, message + "\n");
+}
 
 const schema = z.object({
     tasks: z.array(
@@ -82,14 +89,14 @@ async function callChain(
         promptText,
         inputBlock,
     });
-    console.log("[LLM REQUEST]", formattedPrompt);
+    logToFile(`[LLM REQUEST] ${formattedPrompt}`);
 
     const rawResponse = await model.invoke(formattedPrompt);
     const responseText =
         typeof rawResponse === "string"
             ? rawResponse
             : ((rawResponse as any).content as string);
-    console.log("[LLM RESPONSE]", responseText);
+    logToFile(`[LLM RESPONSE] ${responseText}`);
 
     const result = (await parser.parse(responseText)) as z.infer<typeof schema>;
 


### PR DESCRIPTION
## Summary
- log AI request/response to a file instead of console

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_689cce77d12c8324a76dfe6c955fa262